### PR TITLE
Drop test coverage for Ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,14 @@ language: ruby
 rvm:
   - 2.1.0
   - 2.0.0
-  - 1.9.3
   - ruby-head
   - jruby
-  - jruby-19mode
   - rbx
-  - rbx-19mode
 
 env:
   - MONGOID_VERSION=3
   - MONGOID_VERSION=4
   - MONGOID_VERSION=5
-
 
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ information within Rails applications using Mongoid ORM.
 
 Mongoid::Userstamp is tested on the following versions:
 
-* Ruby 1.9.3, 2.0, and 2.1
-* Rails 3.2 and 4
-* Mongoid 3.1 and 4
+* Ruby 2.0+
+* Rails 3.2, 4.x
+* Mongoid 3.1, 4.x, 5.x
 
 ## Install
 


### PR DESCRIPTION
Ruby 1.9 went end-of-life over a year ago. This PR drops Travis dependency for Ruby 1.9, although it may continue to work.