### PR TITLE
User and Model Module name changed to UserMixin and ModuleMixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * Refactor
   * DEPRECATION: `created_column` config is now `created_name`
   * DEPRECATION: `created_updated` config is now `created_updated`
-  * DEPRECATION: `user_model` config is no longer used. Instead, include Mongoid::Userstamp::User in your user model.
+  * DEPRECATION: `user_model` config is no longer used. Instead, include Mongoid::Userstamp::UserMixin in your user model.
   * Substantial refactoring of all classes and test cases. Among other changes, all access to `Thread.current` variables is now done in the Mongoid::Userstamp module singleton.
 
 ## [0.3.2](https://github.com/tbpro/mongoid_userstamp/releases/tag/v0.3.2) - 2014-01-12

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Mongoid::Userstamp is tested on the following versions:
 Mongoid::Userstamp does the following:
 * Defines Mongoid `belongs_to` relations to the user class for `created_by` and `updated_by` on each class where `Mongoid::Userstamp` is included
 * Automatically tracks the current user via a `before_filter` (see Rails Integration below)
-* Sets the `created_by` and `updated_by` values in `before_save` and `before_update` callbacks respectively on the target models.
+* Sets the `created_by` in `before_validation` only if new_record (before_validation on_create)
+* Sets the `updated_by` value in `before_update` callback on the target models.
 * Adds methods to the user class to check for the current user.
 
 ```ruby
@@ -43,11 +44,11 @@ Mongoid::Userstamp does the following:
     #                   created_name: :creator,
     #                   updated_name: :updater,
   end
- 
+
   # Example user class
   class MyUser
     include Mongoid::Document
-    include Mongoid::Userstamp::User
+    include Mongoid::Userstamp::UserMixin
 
     # optional class-level config override
     # mongoid_userstamp_user reader: :current_my_user
@@ -74,9 +75,9 @@ Mongoid::Userstamp does the following:
 
 Mongoid::Userstamp will not overwrite manually set values in the `creator` and `updater` fields. Specifically:
 
-* The `creator` is only set during the creation of new models (`before_create` callback). Mongoid::Userstamp will not
+* The `creator` is only set during the creation of new models (`before_validation` callback if new_record). Mongoid::Userstamp will not
 overwrite the `creator` field if it already contains a value (i.e. was manually set.)
-* The `updater` is set each time the model is saved (`before_create` callback), which includes the initial
+* The `updater` is set each time the model is saved (`before_validation` callback if new_record), which includes the initial
 creation. Mongoid::Userstamp will not overwrite the `updater` field if it been modified since the last save, as
 per Mongoid's built-in "dirty tracking" feature.
 
@@ -127,14 +128,14 @@ Please note that each model may subscribe to only one user type for its userstam
 ```ruby
   class Admin
     include Mongoid::Document
-    include Mongoid::Userstamp::User
+    include Mongoid::Userstamp::UserMixin
 
     mongoid_userstamp_user reader: :current_admin
   end
 
   class Customer
     include Mongoid::Document
-    include Mongoid::Userstamp::User
+    include Mongoid::Userstamp::UserMixin
 
     mongoid_userstamp_user reader: :current_customer
   end

--- a/lib/mongoid/userstamp.rb
+++ b/lib/mongoid/userstamp.rb
@@ -13,7 +13,7 @@ module Mongoid
 
       def mongoid_userstamp(opts = {})
         mongoid_userstamp_config(opts)
-        self.send(:include, Mongoid::Userstamp::Model) unless self.included_modules.include?(Mongoid::Userstamp::Model)
+        self.send(:include, Mongoid::Userstamp::ModelMixin) unless self.included_modules.include?(Mongoid::Userstamp::ModelMixin)
       end
 
       def mongoid_userstamp_config(opts = {})

--- a/lib/mongoid/userstamp/config/gem_config.rb
+++ b/lib/mongoid/userstamp/config/gem_config.rb
@@ -19,7 +19,7 @@ module Userstamp
 
     # @deprecated
     def user_model=(value)
-      warn 'Mongoid::Userstamp `user_model` config is removed as of v0.4.0. If using a model named other than `User`, please include `Mongoid::Userstamp::User` in your user model instead.'
+      warn 'Mongoid::Userstamp `user_model` config is removed as of v0.4.0. If using a model named other than `User`, please include `Mongoid::Userstamp::UserMixin` in your user model instead.'
     end
 
     # @deprecated

--- a/lib/mongoid/userstamp/mixins/model_mixin.rb
+++ b/lib/mongoid/userstamp/mixins/model_mixin.rb
@@ -3,7 +3,7 @@
 module Mongoid
 module Userstamp
 
-  module Model
+  module ModelMixin
 
     extend ActiveSupport::Concern
 
@@ -12,7 +12,7 @@ module Userstamp
       belongs_to mongoid_userstamp_config.created_name, class_name: mongoid_userstamp_config.user_model, inverse_of: nil
       belongs_to mongoid_userstamp_config.updated_name, class_name: mongoid_userstamp_config.user_model, inverse_of: nil
 
-      before_create :set_created_by
+      before_validation :set_created_by
       before_save :set_updated_by
 
       protected
@@ -20,7 +20,9 @@ module Userstamp
       def set_created_by
         current_user = Mongoid::Userstamp.current_user(self.class.mongoid_userstamp_config.user_model)
         return if current_user.blank? || self.send(self.class.mongoid_userstamp_config.created_name)
-        self.send("#{self.class.mongoid_userstamp_config.created_name}=", current_user)
+        if self.send("#{self.class.mongoid_userstamp_config.created_name}").blank? && self.new_record?
+          self.send("#{self.class.mongoid_userstamp_config.created_name}=", current_user)
+        end
       end
 
       def set_updated_by

--- a/lib/mongoid/userstamp/mixins/user_mixin.rb
+++ b/lib/mongoid/userstamp/mixins/user_mixin.rb
@@ -3,7 +3,7 @@
 module Mongoid
 module Userstamp
 
-  module User
+  module UserMixin
 
     extend ActiveSupport::Concern
 

--- a/lib/mongoid/userstamp/railtie.rb
+++ b/lib/mongoid/userstamp/railtie.rb
@@ -5,11 +5,11 @@ module Userstamp
 
   class Railtie < Rails::Railtie
 
-    # Include Mongoid::Userstamp::User into User class, if not already done
+    # Include Mongoid::Userstamp::UserMixin into User class, if not already done
     config.to_prepare do
       Mongoid::Userstamp.user_classes.each do |user_class|
-        unless user_class.included_modules.include?(Mongoid::Userstamp::User)
-          user_class.send(:include, Mongoid::Userstamp::User)
+        unless user_class.included_modules.include?(Mongoid::Userstamp::UserMixin)
+          user_class.send(:include, Mongoid::Userstamp::UserMixin)
         end
       end
     end
@@ -18,8 +18,8 @@ module Userstamp
     # mongoid_userstamp was not explicitly called
     config.to_prepare do
       Mongoid::Userstamp.model_classes.each do |model_class|
-        unless model_class.included_modules.include?(Mongoid::Userstamp::Model)
-          model_class.send(:include, Mongoid::Userstamp::Model)
+        unless model_class.included_modules.include?(Mongoid::Userstamp::ModelMixin)
+          model_class.send(:include, Mongoid::Userstamp::ModelMixin)
         end
       end
     end

--- a/lib/mongoid_userstamp.rb
+++ b/lib/mongoid_userstamp.rb
@@ -5,6 +5,6 @@ require 'mongoid/userstamp/version'
 require 'mongoid/userstamp/config/gem_config'
 require 'mongoid/userstamp/config/model_config'
 require 'mongoid/userstamp/config/user_config'
-require 'mongoid/userstamp/mixins/user'
-require 'mongoid/userstamp/mixins/model'
+require 'mongoid/userstamp/mixins/user_mixin'
+require 'mongoid/userstamp/mixins/model_mixin'
 require 'mongoid/userstamp/railtie' if defined? Rails

--- a/spec/support/admin.rb
+++ b/spec/support/admin.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 class Admin
   include Mongoid::Document
-  include Mongoid::Userstamp::User
+  include Mongoid::Userstamp::UserMixin
 
   field :name
 end

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 class User
   include Mongoid::Document
-  include Mongoid::Userstamp::User
+  include Mongoid::Userstamp::UserMixin
 
   field :name
 end

--- a/spec/unit/model_spec.rb
+++ b/spec/unit/model_spec.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 require 'spec_helper'
 
-describe Mongoid::Userstamp::Model do
+describe Mongoid::Userstamp::ModelMixin do
 
   subject(:book) { Book.new(name: 'Crafting Rails Applications') }
   subject(:post) { Post.new(title: 'Understanding Rails') }

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 require 'spec_helper'
 
-describe Mongoid::Userstamp::User do
+describe Mongoid::Userstamp::UserMixin do
 
   subject(:book) { Book.new(name: 'Crafting Rails Applications') }
   subject(:post) { Post.new(title: 'Understanding Rails') }


### PR DESCRIPTION
	- User module name was conflicting with model/user hence changed it.
before_create hook changed to before_validation
	- If added validation for created_by_id on user classes module, it fails as we are assigning value in before_create
	- So changed hook to before_validation and if record is new_record then only set created_by value. ( before_validation on: create)