### PR TITLE
Rename User module to UserstampUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Mongoid::Userstamp does the following:
   # Example user class
   class MyUser
     include Mongoid::Document
-    include Mongoid::Userstamp::User
+    include Mongoid::Userstamp::UserstampUser
 
     # optional class-level config override
     # mongoid_userstamp_user reader: :current_my_user
@@ -127,14 +127,14 @@ Please note that each model may subscribe to only one user type for its userstam
 ```ruby
   class Admin
     include Mongoid::Document
-    include Mongoid::Userstamp::User
+    include Mongoid::Userstamp::UserstampUser
 
     mongoid_userstamp_user reader: :current_admin
   end
 
   class Customer
     include Mongoid::Document
-    include Mongoid::Userstamp::User
+    include Mongoid::Userstamp::UserstampUser
 
     mongoid_userstamp_user reader: :current_customer
   end

--- a/lib/mongoid/userstamp/config/gem_config.rb
+++ b/lib/mongoid/userstamp/config/gem_config.rb
@@ -19,7 +19,7 @@ module Userstamp
 
     # @deprecated
     def user_model=(value)
-      warn 'Mongoid::Userstamp `user_model` config is removed as of v0.4.0. If using a model named other than `User`, please include `Mongoid::Userstamp::User` in your user model instead.'
+      warn 'Mongoid::Userstamp `user_model` config is removed as of v0.4.0. If using a model named other than `User`, please include `Mongoid::Userstamp::UserstampUser` in your user model instead.'
     end
 
     # @deprecated

--- a/lib/mongoid/userstamp/mixins/user.rb
+++ b/lib/mongoid/userstamp/mixins/user.rb
@@ -3,7 +3,7 @@
 module Mongoid
 module Userstamp
 
-  module User
+  module UserstampUser
 
     extend ActiveSupport::Concern
 

--- a/lib/mongoid/userstamp/railtie.rb
+++ b/lib/mongoid/userstamp/railtie.rb
@@ -5,7 +5,7 @@ module Userstamp
 
   class Railtie < Rails::Railtie
 
-    # Include Mongoid::Userstamp::User into User class, if not already done
+    # Include Mongoid::Userstamp::UserstampUser into User class, if not already done
     config.to_prepare do
       Mongoid::Userstamp.user_classes.each do |user_class|
         unless user_class.included_modules.include?(Mongoid::Userstamp::UserstampUser)

--- a/lib/mongoid/userstamp/railtie.rb
+++ b/lib/mongoid/userstamp/railtie.rb
@@ -8,8 +8,8 @@ module Userstamp
     # Include Mongoid::Userstamp::User into User class, if not already done
     config.to_prepare do
       Mongoid::Userstamp.user_classes.each do |user_class|
-        unless user_class.included_modules.include?(Mongoid::Userstamp::User)
-          user_class.send(:include, Mongoid::Userstamp::User)
+        unless user_class.included_modules.include?(Mongoid::Userstamp::UserstampUser)
+          user_class.send(:include, Mongoid::Userstamp::UserstampUser)
         end
       end
     end

--- a/spec/support/admin.rb
+++ b/spec/support/admin.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 class Admin
   include Mongoid::Document
-  include Mongoid::Userstamp::User
+  include Mongoid::Userstamp::UserstampUser
 
   field :name
 end

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 class User
   include Mongoid::Document
-  include Mongoid::Userstamp::User
+  include Mongoid::Userstamp::UserstampUser
 
   field :name
 end

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 require 'spec_helper'
 
-describe Mongoid::Userstamp::User do
+describe Mongoid::Userstamp::UserstampUser do
 
   subject(:book) { Book.new(name: 'Crafting Rails Applications') }
   subject(:post) { Post.new(title: 'Understanding Rails') }


### PR DESCRIPTION
User is a very common model name and conflicts with module name in this gem. I have updated it to UserstampUser to remove this conflict.